### PR TITLE
Scripts: read API credentials from (ignored) secrets.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 __pycache__/
+.vscode
+scripts/.cache
+scripts/secrets.py

--- a/scripts/secrets.py
+++ b/scripts/secrets.py
@@ -1,8 +1,0 @@
-"""
-secrets.py
-Store API credentials. Scripts read the fields from this file.
-Please do NOT commit API keys in a public place.
-"""
-
-client_id = "CLIENT_ID_FROM_SPOTIFY"
-client_secret = "CLIENT_SECRET_FROM_SPOTIFY"

--- a/scripts/secrets.py
+++ b/scripts/secrets.py
@@ -1,0 +1,8 @@
+"""
+secrets.py
+Store API credentials. Scripts read the fields from this file.
+Please do NOT commit API keys in a public place.
+"""
+
+client_id = "CLIENT_ID_FROM_SPOTIFY"
+client_secret = "CLIENT_SECRET_FROM_SPOTIFY"

--- a/scripts/spotifyoauth.py
+++ b/scripts/spotifyoauth.py
@@ -2,6 +2,7 @@
 spotifyoauth.py
 Functions to facilitate user login via Spotify.
 """
+import secrets
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
 
@@ -11,8 +12,8 @@ def do_oauth():
     scope = "user-library-read"
 
     # Grab these two fields from the Spotify Developer Dashboard
-    client_id = "nope"
-    client_secret = "nope"
+    client_id = secrets.client_id
+    client_secret = secrets.client_secret
 
     # The redirect URL must match the value set on the Spotify Developer Dashboard
     redirect_uri = "http://localhost:8080"    

--- a/scripts/spotifyoauth.py
+++ b/scripts/spotifyoauth.py
@@ -2,7 +2,7 @@
 spotifyoauth.py
 Functions to facilitate user login via Spotify.
 """
-import secrets
+from . import secrets
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
 


### PR DESCRIPTION
Behold, the smallest PR ever! I'm requesting the team's feedback in order to warm us up to the PR/review process.

The purpose of this PR is to make our files in `scripts/` read our API secrets from a separate file, `secrets.py`.
- In new scripts, **we will need to do two things:**
  - Add an import statement: `import secrets`
  - Read in our API secrets by accessing the fields in `secrets.py`. Ex: `my_client_id = secrets.client_id`.
- `scripts/secrets.py` is included in the `.gitignore` - it *will not* (and *should not*) be publicly committed.

One extra action is required: **you are responsible for creating a local copy of `scripts/secrets.py`.** I'll post a note about this in Discord shortly.

There are other ways to do this, including using other packages and libraries, but I figured this was the simplest way.

That's all for now - let me know your thoughts. 