### PR TITLE
Add endpoint to search Spotify for a song

### DIFF
--- a/controllers.py
+++ b/controllers.py
@@ -125,43 +125,67 @@ def validate_parameter(query, param):
 @action.uses(session)
 def search():
 
-	print(request.body)
-	
-	if request.body is not None:
-		
-		try:
-			body = json.load(request.body)
-			print(body)
-		except JSONDecodeError:
-			response.status = 400
-			return "(sp_search) error: could not decode request body (possibly empty?)"
-	else:
-		response.status = 400
-		return "(sp_search) error: no request body found"
+	# Make sure some query parameter is present
+	if request.query is not None:
 
-	if 'q' in body:
-		search_query = body['q']
-		print("search_query:", search_query)
+		# Make sure query parameter q is present (and not null, empty, or only whitespace)
+		if 'q' in request.query and len(request.query.get('q')) != 0 and request.query.get('q').isspace() is False:
+				
+			# Extract the value of query parameter q
+			search_query = request.query.get('q')
 
-		results = search_for(search_query)
-		print(results)
-			
-		if results == "(search_for) error: not authorized":
-			response.status = 403
-			return "(sp_search) error: not authorized"
+			# Call search_for with the query parameter
+			results = search_for(search_query)
 
+			# If the user is not authorized (session/token expired, not logged in, etc)
+			if results == "(search_for) error: not authorized":
+
+				# Return error 403: forbidden
+				response.status = 403 
+				return "(sp_search) error: not authorized"
+
+			# If the search query was null or empty (and errored out in search_for)
+			elif results == "(search_for) error: search_string null or empty":
+
+				# Return error 400: bad request
+				response.status = 400
+				return "(sp_search) error in search_for: search query (q) null or empty"
+
+			else:
+				# Otherwise, if search_for returned some response:
+				if results is not None:
+					res = []
+				
+					# Loop through the response (JSON) and extract track id, name, artist, album
+					for idx, result in enumerate(results['tracks']['items']):
+						track_id = result['id']
+						track_name = result['name']
+						track_artist = result['artists'][0]['name']
+						track_album = result['album']['name']
+						
+						# Append to an unalphabetized list (to preserve results' rank/order)
+						res.append({
+							"track_id":track_id, 
+							"track_name":track_name, 
+							"track_artist":track_artist, 
+							"track_album":track_album
+						})
+					
+					# Turn the extracted info into a JSON object and return it
+					res_json = json.dumps(res)
+					return res_json
+				
+				# If no results were found (unlikely), say so
+				else:
+					response.status = 404
+					return "(sp_search) error: no results found for search query: ", search_query
+					
+		# If query parameter was not present, was empty, or was only whitespace, return an error
 		else:
-			if results is not None:
-				res = {}
-				#print("Showing 10 results for", search_query, ":")
-				for idx, result in enumerate(results['tracks']['items']):
-					track_id = result['id']
-					track_name = result['name']
-					track_artist = result['artists'][0]['name']
-					track_album = result['album']['name']
-					#print(idx, "- track:", track_name, " | artist:", track_artist, " | album:", track_album)
-					res.update({track_id:{"track_name":track_name, "track_artist":track_artist, "track_album":track_album}})
-				return res
-	else:
-		response.status = 400
-		return "(sp_search) error: search query (q) not found in request body"
+			response.status = 400
+			return "(sp_search) error: search query (q) null or empty"
+	
+	# If we haven't returned anything by now, return an appropriate error
+	else:			
+		response.status = 400 
+		return "(sp_search) error: no query parameters found"

--- a/controllers.py
+++ b/controllers.py
@@ -31,6 +31,7 @@ from .common import db, session, T, cache, auth, logger, authenticated, unauthen
 from .scripts.spotifyoauth import do_oauth, do_callback, get_token
 from .scripts.get_recs import get_recs
 from .scripts.create_playlist import create_playlist
+from .scripts.search import search_for
 
 import spotipy
 
@@ -119,3 +120,7 @@ def recs():
 def validate_parameter(query, param):
     return param in query and len(query.get(param)) != 0 and query.get(param).isspace() is False
 
+@action("sp_search")
+@action.uses(session)
+def search():
+	return search_for("Smash Mouth")

--- a/controllers.py
+++ b/controllers.py
@@ -123,4 +123,15 @@ def validate_parameter(query, param):
 @action("sp_search")
 @action.uses(session)
 def search():
-	return search_for("Smash Mouth")
+	q = "Smash Mouth"
+	results = search_for(q)
+	response = {}
+	print("Showing 10 results for", q, ":")
+	for idx, result in enumerate(results['tracks']['items']):
+		track_id = result['id']
+		track_name = result['name']
+		track_artist = result['artists'][0]['name']
+		track_album = result['album']['name']
+		print(idx, "- track:", track_name, " | artist:", track_artist, " | album:", track_album)
+		response.update({track_id:{"track_name":track_name, "track_artist":track_artist, "track_album":track_album}})
+	return response

--- a/controllers.py
+++ b/controllers.py
@@ -33,7 +33,6 @@ from .scripts.get_recs import get_recs
 from .scripts.create_playlist import create_playlist
 from .scripts.search import search_for
 import json
-from json import JSONDecodeError
 import spotipy
 
 

--- a/scripts/search.py
+++ b/scripts/search.py
@@ -22,5 +22,5 @@ def search_for(search_string):
 		# Return (10) tracks found via search_string
 		return sp.search(q=search_string, type='track')
 
-	return "error: not authorized"
+	return "(search_for) error: not authorized"
 

--- a/scripts/search.py
+++ b/scripts/search.py
@@ -6,7 +6,6 @@ input: search_string
 output: search results from Spotify
 """
 import spotipy
-from spotipy.oauth2 import SpotifyOAuth
 from .spotifyoauth import get_token
 from ..common import session
 

--- a/scripts/search.py
+++ b/scripts/search.py
@@ -1,0 +1,26 @@
+"""
+search.py
+Search Spotify for a given search_string. Returns search results.
+
+input: search_string
+output: search results from Spotify
+"""
+import spotipy
+from spotipy.oauth2 import SpotifyOAuth
+from .spotifyoauth import get_token
+from ..common import session
+
+def search_for(search_string):
+
+	# Get token from session
+	session['token_info'], authorized = get_token()
+
+	if authorized:
+		sp = spotipy.Spotify(auth=session.get('token_info').get('access_token'))
+
+	
+		# Return (10) tracks found via search_string
+		return sp.search(q=search_string, type='track')
+
+	return "error: not authorized"
+

--- a/scripts/search.py
+++ b/scripts/search.py
@@ -18,9 +18,13 @@ def search_for(search_string):
 	if authorized:
 		sp = spotipy.Spotify(auth=session.get('token_info').get('access_token'))
 
-	
-		# Return (10) tracks found via search_string
-		return sp.search(q=search_string, type='track')
-
-	return "(search_for) error: not authorized"
+		# If search_string is null or empty, return an error
+		if search_string is None or len(search_string) == 0:
+			return "(search_for) error: search_string null or empty"
+			
+		else:
+			# Return 10 tracks found via search_string
+			return sp.search(q=search_string, type='track')
+	else:
+		return "(search_for) error: not authorized"
 


### PR DESCRIPTION
The purpose of this PR is twofold:
- Add functionality for a new endpoint to search for a song on Spotify, given a keyword: `/sp_search?q=song+name_here`
- Add a function to call Spotify's API to search for tracks matching the keyword.

More info here: https://github.com/Spotify-Open-Recommendation-Engine/spotify-open-recommendation-engine/wiki/%F0%9F%94%8D-sp_search:-Search-For-a-Song